### PR TITLE
Fixes to address latest libyang-cpp changes

### DIFF
--- a/plugins/ietf-hardware-plugin/src/plugin/callback.hpp
+++ b/plugins/ietf-hardware-plugin/src/plugin/callback.hpp
@@ -255,7 +255,7 @@ struct Callback {
 
             std::string const toPrint(
                 values.value()
-                    .printStr(libyang::DataFormat::JSON, libyang::PrintFlags::WithSiblings)
+                    .printStr(libyang::DataFormat::JSON, libyang::PrintFlags::Siblings)
                     .value());
             logMessage(SR_LL_DBG, toPrint);
         } catch (const std::exception& e) {

--- a/plugins/os-metrics-plugin/src/plugin/utils/globals.h
+++ b/plugins/os-metrics-plugin/src/plugin/utils/globals.h
@@ -77,7 +77,7 @@ static void printCurrentConfig(sysrepo::Session& session,
 
         std::string const toPrint(
             values.value()
-                .printStr(libyang::DataFormat::JSON, libyang::PrintFlags::WithSiblings)
+                .printStr(libyang::DataFormat::JSON, libyang::PrintFlags::Siblings)
                 .value());
         logMessage(SR_LL_DBG, toPrint);
     } catch (const std::exception& e) {


### PR DESCRIPTION
Fix for the latest libyang-cpp changes (https://github.com/CESNET/libyang-cpp/commit/38d5c10009df602594e1b9a53bac41111a9ba430).

The names of the PrintFlags enum have been changed.
```
enum class PrintFlags : uint32_t {
    WithDefaultsExplicit = 0x00,
-    WithSiblings = 0x01,
+   Siblings = 0x01,
    Shrink = 0x02,
-    KeepEmptyCont = 0x04,
+    EmptyContainers = 0x04,
    WithDefaultsTrim = 0x10,
    WithDefaultsAll = 0x20,
    WithDefaultsAllTag = 0x40,
```